### PR TITLE
feat: migrate to ovos-spec-tools

### DIFF
--- a/jurebes/core.py
+++ b/jurebes/core.py
@@ -12,7 +12,7 @@ import joblib
 from sklearn.base import BaseEstimator
 from sklearn.calibration import CalibratedClassifierCV
 
-from jurebes.datasets.expansion import expand_template
+from ovos_spec_tools import expand as expand_template
 
 _WS_RE = re.compile(r"\s+")
 

--- a/jurebes/datasets/expansion.py
+++ b/jurebes/datasets/expansion.py
@@ -1,74 +1,52 @@
-"""Bracket-expansion utilities for training data preprocessing.
+"""Bracket-expansion utilities — deprecated shim over ``ovos_spec_tools``.
 
-Two helpers for Padatious-style template strings:
-
-- :func:`expand_template` — expand ``[optional]`` parts and ``(a|b|c)``
-  alternations into the full cartesian set of realised utterances.
-- :func:`expand_slots`    — also substitute ``{slot}`` placeholders with
-  values drawn from a dictionary.
-
-Pure stdlib. Useful when a user wants to materialise extra training
-samples from a small template grammar before handing the data to
-:class:`jurebes.IntentClassifier`.
-
-Ported from `ovos_utils.bracket_expansion` (Apache-2.0).
+Use :func:`ovos_spec_tools.expand` directly. This module is preserved for
+backward compatibility and will be removed in a future major release.
 """
 
 from __future__ import annotations
 
 import itertools
 import re
+import warnings
 from typing import Dict, List
 
+from ovos_spec_tools import expand as _expand
+from ovos_utils.log import deprecated
 
+from jurebes.version import VERSION_MAJOR
+
+_REMOVAL = f"{VERSION_MAJOR + 1}.0.0"
+
+
+@deprecated(
+    "use 'ovos_spec_tools.expand' instead",
+    _REMOVAL,
+)
 def expand_template(template: str) -> List[str]:
-    """Expand ``[optional]`` and ``(a|b)`` constructs in a template.
-
-    ``"hello [there] (friend|world)"`` →
-    ``["hello friend", "hello there friend", "hello there world", "hello world"]``.
-
-    Returns a sorted, de-duplicated list of all realised strings.
-    """
-    def _expand_optional(text: str) -> str:
-        return re.sub(r"\[([^\[\]]+)\]", lambda m: f"({m.group(1)}|)", text)
-
-    def _expand_alternatives(text: str):
-        parts = []
-        for segment in re.split(r"(\([^\(\)]+\))", text):
-            if segment.startswith("(") and segment.endswith(")"):
-                options = segment[1:-1].split("|")
-                parts.append(options)
-            else:
-                parts.append([segment])
-        return itertools.product(*parts)
-
-    def _fully_expand(texts):
-        result = set(texts)
-        while True:
-            expanded = set()
-            for text in result:
-                options = list(_expand_alternatives(text))
-                expanded.update(
-                    re.sub(r"\s+", " ", "".join(opt)).strip() for opt in options
-                )
-            if expanded == result:
-                break
-            result = expanded
-        return sorted(result)
-
-    return _fully_expand([_expand_optional(template)])
+    """Deprecated — delegate to :func:`ovos_spec_tools.expand`."""
+    warnings.warn(
+        "jurebes.datasets.expansion.expand_template is deprecated; "
+        "use ovos_spec_tools.expand instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return sorted(set(_expand(template)))
 
 
+@deprecated(
+    "use 'ovos_spec_tools.expand' with slot substitution instead",
+    _REMOVAL,
+)
 def expand_slots(template: str, slots: Dict[str, List[str]]) -> List[str]:
-    """Expand alternatives, optionals, then substitute ``{slot}`` placeholders.
-
-    ``slots`` maps slot name → list of replacement values. Each placeholder
-    in the template is replaced with every value from its list and the full
-    cartesian product across placeholders is returned.
-
-    Unknown ``{slots}`` (not in the dict) are left intact.
-    """
-    base = expand_template(template)
+    """Deprecated — expand brackets via ovos_spec_tools then substitute slots."""
+    warnings.warn(
+        "jurebes.datasets.expansion.expand_slots is deprecated; "
+        "use ovos_spec_tools.expand instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    base = sorted(set(_expand(template)))
     out: List[str] = []
     for sentence in base:
         matches = re.findall(r"\{([^\{\}]+)\}", sentence)

--- a/jurebes/opm.py
+++ b/jurebes/opm.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from os.path import isfile
 from typing import Dict, List, Optional, Tuple, Union
 
-from langcodes import closest_match
 from ovos_bus_client.client import MessageBusClient
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session, SessionManager
@@ -14,9 +13,9 @@ from ovos_plugin_manager.templates.pipeline import (
     ConfidenceMatcherPipeline,
     IntentHandlerMatch,
 )
+from ovos_spec_tools import closest_lang, standardize_lang
 from ovos_utils import flatten_list
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.log import LOG
 
 from jurebes import IntentClassifier
@@ -39,11 +38,11 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
         super().__init__(config=config or {}, bus=bus)
 
         core_config = Configuration()
-        self.lang = standardize_lang_tag(core_config.get("lang", "en-US"))
+        self.lang = standardize_lang(core_config.get("lang", "en-US"))
         langs = core_config.get("secondary_langs") or []
         if self.lang not in langs:
             langs.append(self.lang)
-        langs = [standardize_lang_tag(l) for l in langs]
+        langs = [standardize_lang(l) for l in langs]
 
         self.conf_high = self.config.get("conf_high") or 0.8
         self.conf_med = self.config.get("conf_med") or 0.6
@@ -84,7 +83,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
     def _match_level(self, utterances, limit, lang=None, message: Optional[Message] = None):
         LOG.debug(f"Jurebes matching confidence > {limit}")
         utterances = flatten_list(utterances)
-        lang = standardize_lang_tag(lang or self.lang)
+        lang = standardize_lang(lang or self.lang)
         match = self.calc_intent(utterances, lang, message)
         if match is not None and match.confidence > limit:
             skill_id = self._intent_to_skill.get(
@@ -144,7 +143,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
         return samples
 
     def register_intent(self, message: Message):
-        lang = standardize_lang_tag(message.data.get("lang", self.lang))
+        lang = standardize_lang(message.data.get("lang", self.lang))
         if lang not in self.containers:
             return
         name = message.data["name"]
@@ -162,7 +161,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
         self._fitted[lang] = False
 
     def register_entity(self, message: Message):
-        lang = standardize_lang_tag(message.data.get("lang", self.lang))
+        lang = standardize_lang(message.data.get("lang", self.lang))
         if lang not in self.containers or not self.enable_slots:
             return
         name = message.data["name"]
@@ -214,10 +213,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
 
     def _get_closest_lang(self, lang: str) -> Optional[str]:
         if self.containers:
-            lang = standardize_lang_tag(lang)
-            closest, score = closest_match(lang, list(self.containers.keys()))
-            if score < 10:
-                return closest
+            return closest_lang(lang, list(self.containers.keys()))
         return None
 
     def shutdown(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "scikit-learn>=1.4",
     "joblib",
     "ovos-utils",
+    "ovos-spec-tools",
     "ovos-bus-client",
     "ovos-config",
     "ovos-plugin-manager",


### PR DESCRIPTION
Adopts [ovos-spec-tools](https://github.com/OpenVoiceOS/ovos-spec-tools) as the canonical source of bracket expansion and language-tag utilities.

## Replacements

| Local symbol | Replaced by |
|---|---|
| `jurebes.datasets.expansion.expand_template` | `ovos_spec_tools.expand` |
| `ovos_utils.lang.standardize_lang_tag` (in `opm.py`) | `ovos_spec_tools.standardize_lang` |
| `langcodes.closest_match` + `score < 10` boilerplate (in `opm.py._get_closest_lang`) | `ovos_spec_tools.closest_lang` |

## Backward compatibility

`jurebes.datasets.expansion.expand_template` and `expand_slots` remain as deprecation shims (`warnings.warn(DeprecationWarning)` + `@deprecated` from `ovos_utils.log`) with removal scheduled for the next major release. Verified the warning fires via `python -W error::DeprecationWarning -c "from jurebes.datasets.expansion import expand_template; expand_template('hi [there]')"`.

## Policy notes

- Full normalized lang tags everywhere; `macro=True` is not used.
- `ovos-spec-tools` added to `pyproject.toml` `dependencies` (soft, unpinned).

## Tests

`python -m pytest test/` — 308 passed, 6 skipped (pre-existing skips), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Two template expansion functions are now marked deprecated and will emit warnings upon use. These will be removed in a future major release.

* **Chores**
  * Updated template expansion and language handling to use external libraries.
  * Added `ovos-spec-tools` as a project dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/jurebes/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->