### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **J**ust-sklearn **U**tility for **R**eproducible **E**valuation of **B**aselines, **E**stimators and **S**olvers.
 
-A classical-ML text classification research framework — pure scikit-learn, no NLTK, no padacioso.
+A classical-ML text classification research framework, built on plain scikit-learn. It uses no NLTK and no padacioso.
 
-Jurebes lets you wire **any sklearn featurizer + any sklearn classifier** behind a small text-classification API, plus a registry of ready-to-use baselines, a benchmark harness, dataset loaders, a CLI, and an OVOS pipeline plugin.
+Jurebes wires **any sklearn featurizer** to **any sklearn classifier** behind a small text-classification API. It also includes a registry of ready-to-use baselines, a benchmark harness, dataset loaders, a CLI, and an OVOS pipeline plugin.
 
-Intent classification is the flagship application — but the core is domain-agnostic. Spam, sentiment, topic, language-ID and any other single-label text task run on the same API; see [the general text classification guide](docs/guides/general-text-classification.md).
+Intent classification is the main use case, but the core works with any single-label text task. Spam, sentiment, topic, and language-ID tasks run on the same API. See [the general text classification guide](docs/guides/general-text-classification.md).
 
 > *Named in memory of Jurebes, the best dog.*
 
@@ -37,29 +37,29 @@ result = clf.predict("hi there")
 print(result.intent, result.confidence, result.entities)
 ```
 
-Pass any sklearn `Pipeline` / estimator instead of a baseline name; Jurebes auto-wraps non-probabilistic estimators with `CalibratedClassifierCV` so `predict_proba` always works.
+Pass any sklearn `Pipeline` or estimator instead of a baseline name. Jurebes wraps non-probabilistic estimators with `CalibratedClassifierCV` automatically, so `predict_proba` always works.
 
 ## Documentation
 
 Full documentation lives under [`docs/`](docs/):
 
-- [Getting started](docs/getting-started/01-what-is-jurebes.md) — install, first classifier, core concepts, troubleshooting.
-- [Guides](docs/guides/choosing-a-baseline.md) — choosing a baseline, slots, calibration, reproducibility, debugging.
-- [Theory](docs/theory/intent-classification.md) — classical-ML foundations: featurization, linear models, kernels, ensembles, statistical comparison.
-- [API reference](docs/reference/index.md) — every public module, function, dataclass, and CLI flag.
+- [Getting started](docs/getting-started/01-what-is-jurebes.md): install, first classifier, core concepts, troubleshooting.
+- [Guides](docs/guides/choosing-a-baseline.md): choosing a baseline, slots, calibration, reproducibility, debugging.
+- [Theory](docs/theory/intent-classification.md): classical-ML foundations: featurization, linear models, kernels, ensembles, statistical comparison.
+- [API reference](docs/reference/index.md): every public module, function, dataclass, and CLI flag.
 
 ## Research
 
 Jurebes is built as a research framework:
 
-- 48 named baselines tagged into groups (`linear`, `kernel`, `tree`, `naive_bayes`, `neural`, `reduced_dim`, `online`, `strategy`, `feature_engineering`, `ensemble`, `discriminant`, `categorical`). Includes neural-bottleneck autoencoder pipelines (`autoencoder_*`) and dict-input categorical pipelines (`categorical_*`).
-- Hyperparameter search subsystem (`jurebes.search`) supporting grid, random, successive-halving, Bayesian (optional), and genetic (optional) backends.
-- Benchmark harness with multi-metric scoring (`f1_macro`, `accuracy`, `log_loss`, `top_k_accuracy`, ...) and pooled tail-latency percentiles.
+- 48 named baselines tagged into groups (`linear`, `kernel`, `tree`, `naive_bayes`, `neural`, `reduced_dim`, `online`, `strategy`, `feature_engineering`, `ensemble`, `discriminant`, `categorical`). This includes neural-bottleneck autoencoder pipelines (`autoencoder_*`) and dict-input categorical pipelines (`categorical_*`).
+- A hyperparameter search subsystem (`jurebes.search`) with grid, random, successive-halving, Bayesian (optional), and genetic (optional) backends.
+- A benchmark harness with multi-metric scoring (`f1_macro`, `accuracy`, `log_loss`, `top_k_accuracy`, ...) and pooled tail-latency percentiles.
 - See [`docs/research.md`](docs/research.md) and [`docs/search.md`](docs/search.md).
 
 ## Baselines
 
-`BASELINES` is a registry of 48 named factories covering naive Bayes, logistic regression, linear/RBF SVMs, kNN, online learners (SGD, perceptron, passive-aggressive, ridge), tree ensembles (random forest, extra trees, gradient boosting, HistGBM, bagging), shallow MLP, voting, stacking, reduced-dim (LSA/NMF/LDA/autoencoder), multi-class strategy wrappers (OvR/OvO), discriminant analysis, text-statistics composites, and dict-input categorical pipelines. List them:
+`BASELINES` is a registry of 48 named factories. It covers naive Bayes, logistic regression, linear/RBF SVMs, kNN, online learners (SGD, perceptron, passive-aggressive, ridge), tree ensembles (random forest, extra trees, gradient boosting, HistGBM, bagging), a shallow MLP, voting, stacking, reduced-dim methods (LSA/NMF/LDA/autoencoder), multi-class strategy wrappers (OvR/OvO), discriminant analysis, text-statistics composites, and dict-input categorical pipelines. List them:
 
 ```bash
 jurebes list-baselines
@@ -125,9 +125,9 @@ jurebes list-baselines
 | categorical | `categorical_logreg` |
 | categorical | `categorical_random_forest` |
 
-Rows total more than 48 because some baselines (e.g. `bagging_logreg`, `sgd_log`, `hashing_sgd_hinge`) belong to multiple groups. The registry itself contains 48 unique factories.
+Rows total more than 48 because some baselines (for example `bagging_logreg`, `sgd_log`, `hashing_sgd_hinge`) belong to multiple groups. The registry itself holds 48 unique factories.
 
-The `categorical_*` pipelines accept `list[dict[str, str]]` rather than raw text; they are exposed via the programmatic API only and are skipped by text-fixture benchmarks.
+The `categorical_*` pipelines accept `list[dict[str, str]]` instead of raw text. They are available through the programmatic API only, and text-fixture benchmarks skip them.
 
 Register your own:
 
@@ -155,12 +155,12 @@ result = compare(["logreg", "linear_svc", "nb_multinomial"], X, y, k=5)
 print(to_markdown(result))
 ```
 
-`RunResult` captures accuracy, macro/micro F1, per-class F1, training time, predict-latency p50/p95/p99, model size, and confusion matrix.
+`RunResult` captures accuracy, macro/micro F1, per-class F1, training time, predict-latency p50/p95/p99, model size, and the confusion matrix.
 
 ## Slots
 
-Five pluggable taggers covering dictionary, template, sklearn IOB,
-hybrid cascade, and CRF (optional extra). All are accessible through
+Five pluggable taggers cover dictionary, template, sklearn IOB,
+hybrid cascade, and CRF (optional extra). All are available through
 the `TAGGERS` registry and share the same protocol.
 
 ```python
@@ -182,17 +182,17 @@ TAGGERS.names()  # ['dictionary', 'template', 'sklearn_iob', 'hybrid', 'crf']
 
 See [`docs/`](docs/) for the research guide, slot tagger details, and the OVOS deployment notes:
 
-- [`docs/research.md`](docs/research.md) — adding baselines, benchmarks, reports.
-- [`docs/search.md`](docs/search.md) — hyperparameter search backends.
-- [`docs/slots.md`](docs/slots.md) — IOB slot tagger and token features.
-- [`docs/opm.md`](docs/opm.md) — OVOS pipeline plugin configuration.
-- [`MIGRATION.md`](MIGRATION.md) — porting from prior `JurebesIntentContainer` API.
+- [`docs/research.md`](docs/research.md): adding baselines, benchmarks, reports.
+- [`docs/search.md`](docs/search.md): hyperparameter search backends.
+- [`docs/slots.md`](docs/slots.md): IOB slot tagger and token features.
+- [`docs/opm.md`](docs/opm.md): OVOS pipeline plugin configuration.
+- [`MIGRATION.md`](MIGRATION.md): porting from the prior `JurebesIntentContainer` API.
 
 ## Examples
 
-Runnable cell-celled scripts live in [`examples/notebooks/`](examples/notebooks/):
+Runnable, cell-marked scripts live in [`examples/notebooks/`](examples/notebooks/):
 
-- [`snips_quickstart.py`](examples/notebooks/snips_quickstart.py) — fetch SNIPS, train, evaluate.
-- [`banking77_full_research_flow.py`](examples/notebooks/banking77_full_research_flow.py) — compare baselines, run Friedman+Nemenyi, tune the winner, evaluate on holdout.
+- [`snips_quickstart.py`](examples/notebooks/snips_quickstart.py): fetch SNIPS, train, evaluate.
+- [`banking77_full_research_flow.py`](examples/notebooks/banking77_full_research_flow.py): compare baselines, run Friedman+Nemenyi, tune the winner, evaluate on a holdout set.
 
-Both require `pip install jurebes[hf,bench-plot]`.
+Both examples need `pip install jurebes[hf,bench-plot]`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 **J**ust-sklearn **U**tility for **R**eproducible **E**valuation of **B**aselines, **E**stimators and **S**olvers.
 
 A classical-ML text classification research framework. Intent
-classification is the flagship application; the core works for any
+classification is the flagship application, but the core works for any
 single-label text task (spam, sentiment, topic, language-ID).
 
 > *Named in memory of Jurebes, the best dog.*
@@ -68,7 +68,7 @@ single-label text task (spam, sentiment, topic, language-ID).
 - [Active-learning primitives](reference/active-learning.md)
 - [Semi-supervised primitives](reference/semi-supervised.md)
 - [Search subsystem](search.md)
-- [Slot taggers](slots.md) — dictionary, template, sklearn IOB, hybrid, CRF (`TAGGERS` registry)
+- [Slot taggers](slots.md): dictionary, template, sklearn IOB, hybrid, CRF (`TAGGERS` registry)
 - [Slot tagger reference](reference/slots.md)
 - [OVOS pipeline plugin](opm.md)
 
@@ -85,5 +85,5 @@ single-label text task (spam, sentiment, topic, language-ID).
 ## Other
 
 - [Research framework deep dive](research.md)
-- [Tutorial scripts library](../examples/tutorials/README.md) — runnable concept demos.
+- [Tutorial scripts library](../examples/tutorials/README.md): runnable concept demos.
 - [Migration from previous APIs](../MIGRATION.md)

--- a/docs/opm.md
+++ b/docs/opm.md
@@ -1,19 +1,19 @@
 # OVOS pipeline plugin
 
-`jurebes.opm:JurebesPipeline` is a `ConfidenceMatcherPipeline` registered under the entry-point `ovos-jurebes-pipeline-plugin`.
+`jurebes.opm:JurebesPipeline` is a `ConfidenceMatcherPipeline` registered under the entry point `ovos-jurebes-pipeline-plugin`.
 
-## Behaviour
+## Behavior
 
-- One `IntentClassifier` per configured language.
-- Listens on the standard padatious messagebus events:
+- One `IntentClassifier` runs per configured language.
+- The plugin listens on the standard padatious messagebus events:
   - `padatious:register_intent`
   - `padatious:register_entity`
   - `detach_intent`
   - `detach_skill`
   - `mycroft.ready`
-- Exact normalised matches are short-circuited via an internal `{(lang, norm_utt): intent}` dict; everything else goes through the sklearn estimator.
-- Lazy fit: any registration after `mycroft.ready` triggers a re-fit on next match.
-- Session-aware: respects `SessionManager.blacklisted_intents` / `blacklisted_skills`.
+- An internal `{(lang, norm_utt): intent}` dict short-circuits exact normalized matches. Everything else goes through the sklearn estimator.
+- Fit is lazy. Any registration after `mycroft.ready` triggers a re-fit on the next match.
+- The plugin respects `SessionManager.blacklisted_intents` and `blacklisted_skills`.
 
 ## Configuration
 
@@ -36,12 +36,12 @@ In `mycroft.conf` (JSON):
 }
 ```
 
-`baseline` accepts any name registered in `BASELINES`. `enable_slots` toggles the `SklearnIOBTagger`. The three `conf_*` thresholds map onto the `ConfidenceMatcherPipeline` high/med/low buckets.
+`baseline` accepts any name registered in `BASELINES`. `enable_slots` toggles the `SklearnIOBTagger`. The three `conf_*` thresholds map onto the `ConfidenceMatcherPipeline` high, medium, and low buckets.
 
 ## Caveats
 
-- Slot extraction comes only from the trained `SklearnIOBTagger`; disabling slots removes all slot extraction.
-- Exact matches are handled in-process via a `{(lang, norm_utt): intent}` cache. For typo tolerance, pick a char-ngram baseline such as `logreg_char`, `union_logreg`, or `linear_svc_char`.
+- Slot extraction comes only from the trained `SklearnIOBTagger`. Disabling slots removes all slot extraction.
+- The plugin handles exact matches in-process through a `{(lang, norm_utt): intent}` cache. For typo tolerance, pick a char-ngram baseline such as `logreg_char`, `union_logreg`, or `linear_svc_char`.
 
 ---
-[← back to docs index](index.md)
+[Home](index.md)

--- a/docs/research.md
+++ b/docs/research.md
@@ -2,7 +2,7 @@
 
 ## Adding a featurizer
 
-Featurizers are zero-arg builders returning a fresh sklearn transformer or `Pipeline`. Add them to `jurebes/featurizers.py`:
+Featurizers are zero-arg builders that return a fresh sklearn transformer or `Pipeline`. Add them to `jurebes/featurizers.py`:
 
 ```python
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -11,7 +11,7 @@ def tfidf_word_bigrams():
     return TfidfVectorizer(ngram_range=(1, 2), sublinear_tf=True)
 ```
 
-Featurizers compose freely with the existing ones; `feature_union(builder_a, builder_b, ...)` returns a `FeatureUnion` over their outputs.
+Featurizers compose freely with the existing ones. `feature_union(builder_a, builder_b, ...)` returns a `FeatureUnion` over their outputs.
 
 ## Adding a baseline
 
@@ -30,13 +30,13 @@ BASELINES.register(
 )
 ```
 
-Factories are called fresh per run so cross-validation gets clean estimators.
+Jurebes calls each factory fresh per run, so cross-validation gets clean estimators.
 
-The bundled registry uses a dict-literal at `jurebes/baselines.py::BASELINE_SPECS`; new entries can be added there directly and then tagged into a group via `_GROUPS` so the CLI's `@<group>` selector works.
+The bundled registry uses a dict literal at `jurebes/baselines.py::BASELINE_SPECS`. Add new entries there directly, then tag them into a group through `_GROUPS` so the CLI's `@<group>` selector works.
 
 ## Adding a search backend
 
-The search subsystem (`jurebes/search/`) dispatches on a `backend` string to a per-backend `run()` function. To add a backend, write `jurebes/search/<name>.py` exposing a `run(*, factory, param_space, X, y, backend, scoring, cv, n_iter, seed, n_jobs, verbose) -> dict` and add it to the `_BACKENDS` tuple plus the dispatch ladder in `search/api.py`. Optional dependencies must be lazy-imported with a clear `ImportError("install jurebes[<extra>] to use the <name> backend")`.
+The search subsystem (`jurebes/search/`) dispatches on a `backend` string to a per-backend `run()` function. To add a backend, write `jurebes/search/<name>.py` that exposes a `run(*, factory, param_space, X, y, backend, scoring, cv, n_iter, seed, n_jobs, verbose) -> dict` function, then add it to the `_BACKENDS` tuple and the dispatch ladder in `search/api.py`. Lazy-import optional dependencies with a clear `ImportError("install jurebes[<extra>] to use the <name> backend")`.
 
 For non-probabilistic estimators (`LinearSVC`, `RidgeClassifier`, `Perceptron`, `PassiveAggressiveClassifier`, `SGDClassifier(loss="hinge")`), wrap with `sklearn.calibration.CalibratedClassifierCV(cv=3)` so `predict_proba` works.
 
@@ -60,8 +60,8 @@ jurebes benchmark --dataset data.csv --baselines logreg --format json --out repo
 
 ## Reported metric caveats
 
-- `model_size_bytes` is the uncompressed joblib pickle size. Real on-disk size will be smaller when joblib's default zlib compression is enabled at save time.
-- Per-fold `p50_ms`, `p95_ms`, `p99_ms` are computed *within* each fold and then averaged across folds. This is a per-fold percentile, not a pooled percentile across all predictions. The pooled fields `p50_ms_pooled`, `p95_ms_pooled`, `p99_ms_pooled` and `mean_ms` are computed over the flat list of every per-prediction latency observed across all folds; prefer them for tail-latency reporting.
+- `model_size_bytes` is the uncompressed joblib pickle size. The real on-disk size is smaller when joblib's default zlib compression is enabled at save time.
+- Per-fold `p50_ms`, `p95_ms`, and `p99_ms` are computed within each fold, then averaged across folds. This is a per-fold percentile, not a pooled percentile across all predictions. The pooled fields `p50_ms_pooled`, `p95_ms_pooled`, `p99_ms_pooled`, and `mean_ms` are computed over the flat list of every per-prediction latency observed across all folds. Prefer them for tail-latency reporting.
 
 ## Cookbook
 
@@ -135,21 +135,21 @@ print(to_markdown(result, sort_by="p95_ms", precision=3))
 | column | meaning |
 | --- | --- |
 | accuracy | mean across CV folds |
-| macro_f1 | unweighted mean F1 per class — penalises poor-minority performance |
-| micro_f1 | global F1 — equals accuracy in multi-class single-label setups |
+| macro_f1 | unweighted mean F1 per class; penalizes poor minority-class performance |
+| micro_f1 | global F1; equals accuracy in multi-class single-label setups |
 | train_s | mean training seconds per fold |
 | p50_ms / p95_ms | per-fold per-utterance inference latency percentiles, averaged across folds |
 | predict_ms_p95_pooled | pooled p95 over every per-prediction latency across all folds |
 | predict_ms_p99_pooled | pooled p99 over every per-prediction latency across all folds |
-| size_kb | serialised model size via `joblib.dump` to an in-memory buffer |
-| extra_scores | dict of any extra scoring metrics requested via `scoring=` |
+| size_kb | serialized model size via `joblib.dump` to an in-memory buffer |
+| extra_scores | dict of any extra scoring metrics requested through `scoring=` |
 | group | the `BASELINES` group tag this baseline belongs to (or `None` for ad-hoc estimators) |
 
-Use `to_json(comparison)` for downstream plotting / aggregation; every value is JSON-serialisable.
+Use `to_json(comparison)` for downstream plotting or aggregation. Every value is JSON-serializable.
 
 ### Performance notes
 
-The numbers below are illustrative orders of magnitude, not measured benchmarks — actual values depend on dataset size, vocabulary, hardware, and joblib compression settings.
+The numbers below are illustrative orders of magnitude, not measured benchmarks. Actual values depend on dataset size, vocabulary, hardware, and joblib compression settings.
 
 | baseline family | train (relative) | p95 latency (relative) | model size (relative) |
 | --- | --- | --- | --- |
@@ -166,49 +166,50 @@ The numbers below are illustrative orders of magnitude, not measured benchmarks 
 
 - `load_csv(path, text="text", label="intent")`
 - `load_jsonl(path, text="text", label="intent")`
-- `load_ovos_intents(directory)` — recurses for `.intent` / `.voc` / `.entity` files.
-- `load_hf(name, split)` — optional `jurebes[hf]` extra; lazy-imports `datasets`.
+- `load_ovos_intents(directory)`: recurses for `.intent` / `.voc` / `.entity` files.
+- `load_hf(name, split)`: optional `jurebes[hf]` extra; lazy-imports `datasets`.
 
 ## Canonical datasets
 
-Six canonical intent-benchmark loaders live in `jurebes.datasets.canonical`
-and are also reachable from the CLI as `--dataset @<name>`:
+`jurebes.datasets.canonical` provides six canonical intent-benchmark loaders,
+also reachable from the CLI as `--dataset @<name>`:
 
-- `load_snips` — SNIPS NLU benchmark (HF `benayas/snips`, 7 intents).
-- `load_clinc` — CLINC150 OOS (HF `clinc_oos`, config `plus`, 151 intents incl. `oos`).
-- `load_banking77` — fine-grained banking intents (HF `banking77`, 77 intents).
-- `load_hwu64` — home-assistant intents (HF `DeepPavlov/hwu64`, 64 intents).
-- `load_atis` — Air Travel Information System (HF `tuetschek/atis`).
-- `load_massive` — multilingual SLU benchmark (HF `AmazonScience/massive`, 60 intents x 51 locales).
+- `load_snips`: SNIPS NLU benchmark (HF `benayas/snips`, 7 intents).
+- `load_clinc`: CLINC150 OOS (HF `clinc_oos`, config `plus`, 151 intents incl. `oos`).
+- `load_banking77`: fine-grained banking intents (HF `banking77`, 77 intents).
+- `load_hwu64`: home-assistant intents (HF `DeepPavlov/hwu64`, 64 intents).
+- `load_atis`: Air Travel Information System (HF `tuetschek/atis`).
+- `load_massive`: multilingual SLU benchmark (HF `AmazonScience/massive`, 60 intents x 51 locales).
 
-Each loader returns `(X, y)` and raises `ImportError("install jurebes[hf] …")`
-if the `datasets` extra is missing. Caching is handled by HF.
+Each loader returns `(X, y)` and raises `ImportError("install jurebes[hf] ...")`
+if the `datasets` extra is missing. HF handles caching.
 
 ## Statistical comparison
 
 `jurebes.benchmark.stats` provides the tests recommended by Demšar (2006),
-"Statistical Comparisons of Classifiers over Multiple Data Sets" (JMLR 7):
+["Statistical Comparisons of Classifiers over Multiple Data Sets"](https://www.jmlr.org/papers/v7/demsar06a.html) (JMLR 7):
 
-- `paired_t_test_cv(a, b)` — paired Student's t-test on per-fold CV scores.
-  Assumes scores are roughly normal; use when comparing two models on a
+- `paired_t_test_cv(a, b)`: a paired Student's t-test on per-fold CV scores.
+  It assumes scores are roughly normal. Use it to compare two models on a
   single dataset with k-fold CV.
-- `wilcoxon_signed_rank_cv(a, b)` — non-parametric drop-in for paired-t
+- `wilcoxon_signed_rank_cv(a, b)`: a non-parametric drop-in for paired-t
   when normality is suspect or k is small.
-- `mcnemar_test(preds_a, preds_b, y_true)` — paired test on per-sample
-  correctness (contingency table). Use on a held-out test set with two
-  models; mid-p continuity correction.
-- `friedman_nemenyi(fold_scores)` — Friedman omnibus across three or more
-  baselines, followed by post-hoc Nemenyi pairwise comparison. Use when
-  comparing many baselines across multiple datasets or folds.
-- `critical_difference(fold_scores)` — average ranks plus the
-  critical-difference threshold; renders as ASCII table by default, with
-  `to_matplotlib(ax)` available when `jurebes[bench-plot]` is installed.
+- `mcnemar_test(preds_a, preds_b, y_true)`: a paired test on per-sample
+  correctness (contingency table), with mid-p continuity correction. Use it
+  on a held-out test set with two models.
+- `friedman_nemenyi(fold_scores)`: a Friedman omnibus test across three or
+  more baselines, followed by a post-hoc Nemenyi pairwise comparison. Use it
+  when comparing many baselines across multiple datasets or folds.
+- `critical_difference(fold_scores)`: average ranks plus the
+  critical-difference threshold. It renders as an ASCII table by default,
+  with `to_matplotlib(ax)` available when `jurebes[bench-plot]` is installed.
 
 The `to_markdown(result, with_significance=True)` report adds either a
-Critical Difference subsection (>=3 baselines) or paired-t + Wilcoxon
-rows (exactly 2 baselines) for the chosen metric (default `f1_macro`).
-The CLI exposes the same via `jurebes benchmark --with-significance` and
-the `jurebes stats` subcommand for offline analysis of saved runs.
+Critical Difference subsection (three or more baselines) or paired-t and
+Wilcoxon rows (exactly two baselines) for the chosen metric (default
+`f1_macro`). The CLI exposes the same feature through
+`jurebes benchmark --with-significance` and the `jurebes stats` subcommand
+for offline analysis of saved runs.
 
 ---
-[← back to docs index](index.md)
+[Home](index.md)

--- a/docs/search.md
+++ b/docs/search.md
@@ -2,9 +2,9 @@
 
 `jurebes.search` provides a unified `search()` entry point over multiple
 hyperparameter-search backends. Every backend returns a
-:class:`SearchResult` whose ``best_estimator`` is a fitted
-:class:`IntentClassifier` — ready to call ``predict()`` on or save with
-``IntentClassifier.save(path)``.
+`SearchResult` whose `best_estimator` is a fitted
+`IntentClassifier`, ready to call `predict()` on or save with
+`IntentClassifier.save(path)`.
 
 ## Quickstart
 
@@ -22,12 +22,12 @@ print(r.best_score, r.best_params)
 
 | backend          | dep                              | notes                                                       |
 | ---------------- | -------------------------------- | ----------------------------------------------------------- |
-| `grid`           | core                             | exhaustive `GridSearchCV`; cost = product of grid sizes.    |
-| `halving_grid`   | core (experimental)              | successive-halving over the grid; cheapest on big spaces.   |
-| `random`         | core                             | `RandomizedSearchCV` — default; trade `n_iter` for cost.    |
+| `grid`           | core                             | exhaustive `GridSearchCV`, cost equals the product of grid sizes. |
+| `halving_grid`   | core (experimental)              | successive-halving over the grid, cheapest on big spaces.   |
+| `random`         | core                             | `RandomizedSearchCV`, the default. Trade `n_iter` for cost. |
 | `halving_random` | core (experimental)              | successive-halving sampling.                                |
-| `bayes`          | `jurebes[search-bayes]` (skopt)  | Bayesian optimisation; needs Real/Categorical Dimensions.   |
-| `genetic`        | `jurebes[search-genetic]`        | Genetic algorithm via sklearn-genetic-opt.                  |
+| `bayes`          | `jurebes[search-bayes]` (skopt)  | Bayesian optimization, needs Real/Categorical Dimensions.   |
+| `genetic`        | `jurebes[search-genetic]`        | genetic algorithm through sklearn-genetic-opt.              |
 
 Optional backends emit a clear `ImportError("install jurebes[<extra>] to use the <name> backend")` if the dependency is missing.
 
@@ -36,29 +36,29 @@ Optional backends emit a clear `ImportError("install jurebes[<extra>] to use the
 ```python
 from jurebes.search import search
 
-# grid — exhaustive over a discrete space
+# grid - exhaustive over a discrete space
 search("logreg", {"clf__C": [0.1, 1.0, 10.0]}, X, y, backend="grid", cv=5)
 
-# halving_grid — successive-halving over a grid; n_iter is treated as n_candidates
+# halving_grid - successive-halving over a grid; n_iter is treated as n_candidates
 search("logreg", {"clf__C": [0.1, 1.0, 10.0]}, X, y,
        backend="halving_grid", n_iter=3, cv=5)
 
-# random — sampled n_iter draws
+# random - sampled n_iter draws
 search("logreg", {"clf__C": [0.01, 0.1, 1.0, 10.0]}, X, y,
        backend="random", n_iter=40, cv=5)
 
-# halving_random — successive-halving sampling; n_iter → n_candidates
+# halving_random - successive-halving sampling; n_iter -> n_candidates
 search("logreg", {"clf__C": [0.01, 0.1, 1.0, 10.0]}, X, y,
        backend="halving_random", n_iter=20, cv=5)
 
-# bayes — uses skopt dimensions
+# bayes - uses skopt dimensions
 from skopt.space import Real, Integer, Categorical
 search("logreg",
        {"clf__C": Real(1e-3, 1e2, prior="log-uniform"),
         "feat__ngram_range": Categorical([(1, 1), (1, 2)])},
        X, y, backend="bayes", n_iter=30, cv=5)
 
-# genetic — uses sklearn-genetic-opt dimensions
+# genetic - uses sklearn-genetic-opt dimensions
 from sklearn_genetic.space import Continuous, Integer, Categorical
 search("logreg",
        {"clf__C": Continuous(1e-3, 1e2, distribution="log-uniform"),
@@ -68,7 +68,7 @@ search("logreg",
 
 ### `n_iter` vs `n_candidates`
 
-The halving backends (`halving_grid`, `halving_random`) wrap sklearn's `Halving*SearchCV`, which accepts `n_candidates` rather than `n_iter`. Jurebes accepts a unified `n_iter` argument across every backend and forwards it as `n_candidates` for the halving variants. For `grid`, `n_iter` is ignored (the grid is exhaustive). For `random`, `bayes`, and `genetic`, `n_iter` is the number of candidate evaluations.
+The halving backends (`halving_grid`, `halving_random`) wrap sklearn's `Halving*SearchCV`, which accepts `n_candidates` rather than `n_iter`. Jurebes accepts a unified `n_iter` argument across every backend and forwards it as `n_candidates` for the halving variants. For `grid`, Jurebes ignores `n_iter` because the grid is exhaustive. For `random`, `bayes`, and `genetic`, `n_iter` is the number of candidate evaluations.
 
 ## Predefined spaces
 
@@ -83,11 +83,11 @@ spaces.for_baseline("nb_multinomial")
 #  'clf__alpha': [0.01, 0.1, 0.5, 1.0]}
 ```
 
-For backends like `bayes` you need to translate categorical lists into
-`skopt.space.{Real, Integer, Categorical}` dimensions; for `genetic` use
+For backends like `bayes`, translate categorical lists into
+`skopt.space.{Real, Integer, Categorical}` dimensions. For `genetic`, use
 `sklearn_genetic.space.{Continuous, Integer, Categorical}`.
 
-`spaces.for_baseline()` only covers a curated subset of registered baselines (see `spaces.available()`); calling it with a baseline outside that set raises `KeyError`. Provide your own space dict in that case.
+`spaces.for_baseline()` covers only a curated subset of registered baselines (see `spaces.available()`). Calling it with a baseline outside that set raises `KeyError`. Provide your own space dict in that case.
 
 ## CLI
 
@@ -105,4 +105,4 @@ jurebes search --dataset data.csv --baseline nb_multinomial \
 ```
 
 ---
-[← back to docs index](index.md)
+[Home](index.md)

--- a/docs/slots.md
+++ b/docs/slots.md
@@ -1,9 +1,9 @@
 # Slot tagging
 
-Jurebes exposes five pluggable slot-tagging strategies through the
-`TAGGERS` registry. They share a common protocol — `add_entity`,
-`fit`, `predict`, `tag`, `save`, `load` — and can be swapped under any
-`IntentClassifier`.
+Jurebes exposes six pluggable slot-tagging strategies through the
+`TAGGERS` registry. They share a common protocol (`add_entity`,
+`fit`, `predict`, `tag`, `save`, `load`) and you can swap any of them
+under an `IntentClassifier`.
 
 ## Strategy comparison
 
@@ -16,7 +16,7 @@ Jurebes exposes five pluggable slot-tagging strategies through the
 | `hybrid`        | per stage | yes          | high             | scikit-learn      |
 | `crf`           | sklearn-crfsuite | yes   | highest          | `jurebes[slots-crf]` |
 
-## `DictionaryTagger` — gazetteer regex
+## `DictionaryTagger`: gazetteer regex
 
 ```python
 from jurebes.slots import DictionaryTagger
@@ -27,11 +27,11 @@ t.predict("weather in paris")        # {"city": "paris"}
 t.predict("weather in new york")     # {"city": "new york"}
 ```
 
-Single-word entries are word-boundary anchored; multi-token entries are
-matched as exact substrings. Case-insensitive by default; flip
-`case_sensitive=True` for strict matching. No training required.
+Single-word entries are word-boundary anchored. Multi-token entries are
+matched as exact substrings. Matching is case-insensitive by default; set
+`case_sensitive=True` for strict matching. This tagger needs no training.
 
-## `TemplateTagger` — `{slot}` regex templates
+## `TemplateTagger`: `{slot}` regex templates
 
 ```python
 from jurebes.slots import TemplateTagger
@@ -42,15 +42,15 @@ t.fit()
 t.predict("temperature in berlin")   # {"city": "berlin"}
 ```
 
-`{slot}` placeholders become named regex groups; `(a|b)` becomes a
-grouped alternation. The first matching template wins
-(longest-template-first for determinism).
+`{slot}` placeholders become named regex groups, and `(a|b)` becomes a
+grouped alternation. The first matching template wins. Templates are
+tried longest-first for determinism.
 
-## `SklearnIOBTagger` — per-token sklearn classifier
+## `SklearnIOBTagger`: per-token sklearn classifier
 
-Default pipeline: `DictVectorizer` + `LogisticRegression`. Trains on
-token-level IOB tags expanded from `{entity}` placeholders in the
-intent samples.
+The default pipeline is `DictVectorizer` plus `LogisticRegression`. It
+trains on token-level IOB tags expanded from `{entity}` placeholders in
+the intent samples.
 
 ```python
 from jurebes.slots import SklearnIOBTagger
@@ -71,7 +71,7 @@ Regex: `re.findall(r"\w+|[^\w\s]", text)`. No nltk.
 `lower`, `suffix2/3`, `prefix2/3`, `is_upper`, `is_title`,
 `is_digit`, `has_digit`, `bos`, `eos`, `prev_word`, `next_word`.
 
-## `HybridCascadeTagger` — dict → template → IOB cascade
+## `HybridCascadeTagger`: dict to template to IOB cascade
 
 ```python
 from jurebes.slots import HybridCascadeTagger
@@ -84,10 +84,10 @@ h.predict("weather in paris")        # {"city": "paris"}
 h.predict("weather in berlin")       # {"city": "berlin"} via template fallback
 ```
 
-Constituent taggers run in order; earlier taggers win on key collisions.
-Pass a custom list via `HybridCascadeTagger(taggers=[...])`.
+Constituent taggers run in order, and earlier taggers win on key collisions.
+Pass a custom list through `HybridCascadeTagger(taggers=[...])`.
 
-## `KNNTagger` — nearest-utterance tag transfer
+## `KNNTagger`: nearest-utterance tag transfer
 
 ```python
 from jurebes.slots import KNNTagger
@@ -98,16 +98,16 @@ t.fit({"weather": ["weather in {city}", "forecast for {city}"]})
 t.predict("weather in tokyo")        # {"city": "tokyo"}
 ```
 
-Training utterances are TF-IDF-vectorised (char 3-5 n-grams by default);
-at predict time the input is matched against the `k` nearest neighbours
-via `sklearn.neighbors.NearestNeighbors`, and their IOB tags are
-majority-voted onto the input by token position. The pattern transfers
-to unseen entity values whenever the surrounding context matches a
-trained template — `tokyo` above was never registered as a `city`.
+Training utterances are TF-IDF-vectorized (char 3-5 n-grams by default).
+At predict time, the tagger matches the input against the `k` nearest
+neighbors through `sklearn.neighbors.NearestNeighbors`, then majority-votes
+their IOB tags onto the input by token position. The pattern transfers to
+unseen entity values whenever the surrounding context matches a trained
+template. In the example above, `tokyo` was never registered as a `city`.
 
 Tune the surface vectoriser by passing your own `vectorizer=` argument.
 
-## `CRFTagger` — optional sklearn-crfsuite
+## `CRFTagger`: optional sklearn-crfsuite
 
 Install the extra:
 
@@ -123,8 +123,8 @@ t.add_entity("name", ["bob", "alice"])
 t.fit({"name": ["my name is {name}", "call me {name}"]})
 ```
 
-Same feature dictionaries as `SklearnIOBTagger`; under the hood trains
-`sklearn_crfsuite.CRF(algorithm='lbfgs', max_iterations=100)`.
+This tagger uses the same feature dictionaries as `SklearnIOBTagger`.
+Under the hood, it trains `sklearn_crfsuite.CRF(algorithm='lbfgs', max_iterations=100)`.
 
 ## Registry
 
@@ -145,21 +145,21 @@ clf = IntentClassifier(tagger="dictionary")
 
 ## When to use which
 
-- **`dictionary`** — closed-set slots (timezones, ISO codes, known
+- **`dictionary`**: closed-set slots (timezones, ISO codes, known
   device names). Zero training cost.
-- **`template`** — small command grammars with predictable phrasings.
+- **`template`**: small command grammars with predictable phrasings.
   Handles unseen slot values cleanly.
-- **`sklearn_iob`** — broader coverage with moderate training data;
-  generalises beyond seen templates.
-- **`hybrid`** — production default. Dictionary catches the easy
-  cases; template handles known phrasings; IOB picks up the rest.
-- **`crf`** — when sequence structure matters and the extra dependency
+- **`sklearn_iob`**: broader coverage with moderate training data.
+  Generalizes beyond seen templates.
+- **`hybrid`**: production default. Dictionary catches the easy
+  cases, template handles known phrasings, and IOB picks up the rest.
+- **`crf`**: when sequence structure matters and the extra dependency
   is acceptable.
 
 ## Persistence
 
-All taggers expose `save(path)` / `load(path)`. `DictionaryTagger`
-and `TemplateTagger` persist as JSON; the sklearn-backed taggers and
+All taggers expose `save(path)` and `load(path)`. `DictionaryTagger`
+and `TemplateTagger` persist as JSON. The sklearn-backed taggers and
 `HybridCascadeTagger` use joblib.
 
 ## Benchmark harness
@@ -181,4 +181,4 @@ print(result.to_markdown())
 ```
 
 ---
-[← back to docs index](index.md)
+[Home](index.md)


### PR DESCRIPTION
Rewrites README.md and the top-level docs/*.md pages (index, opm, research, search, slots) for clarity, using Simplified Technical English. Every fact, code block, and link is preserved; only prose and wording changed. Docs pages get a `[Home](index.md)` navigation footer.

Rewritten with Claude Fable 5 using the ste-writing skill; linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the project overview, examples, research guidance, and navigation across the documentation.
  * Clarified usage of pipelines, estimators, calibration, dataset loaders, search backends, and performance metrics.
  * Updated slot-tagging documentation to cover six strategies and improved strategy selection guidance.
  * Standardized formatting, terminology, headings, code examples, and links throughout the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->