### PR TITLE
feat: configurable exact-match shortcut (exact_match)

### DIFF
--- a/jurebes/opm.py
+++ b/jurebes/opm.py
@@ -49,6 +49,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
         self.conf_low = self.config.get("conf_low") or 0.4
         self.baseline = self.config.get("baseline", "linear_svc")
         self.enable_slots = bool(self.config.get("enable_slots", True))
+        self.exact_match = bool(self.config.get("exact_match", True))
 
         self.containers: Dict[str, IntentClassifier] = {}
         for lang in langs:
@@ -202,7 +203,7 @@ class JurebesPipeline(ConfidenceMatcherPipeline):
 
         results = []
         for utt in utterances:
-            exact = self._exact.get((lang, _normalize(utt)))
+            exact = self._exact.get((lang, _normalize(utt))) if self.exact_match else None
             if exact and exact not in sess.blacklisted_intents:
                 results.append(_Match(exact, 1.0, {}, utt))
                 continue

--- a/test/test_opm.py
+++ b/test/test_opm.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 pytest.importorskip("ovos_plugin_manager")
@@ -5,6 +7,7 @@ pytest.importorskip("ovos_plugin_manager")
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 
+import jurebes.opm as opm_mod
 from jurebes.opm import JurebesPipeline
 
 
@@ -109,3 +112,46 @@ def test_opm_exact_match():
     match = pipe.match_high(["hello"], "en-US", Message("test"))
     assert match is not None
     assert match.match_type == "skill.hello:hello"
+
+
+def _register_hello_and_joke(pipe, bus):
+    bus.emit(Message("padatious:register_intent", {
+        "name": "skill.hello:hello",
+        "lang": "en-US",
+        "samples": ["hello", "hi"],
+    }))
+    bus.emit(Message("padatious:register_intent", {
+        "name": "skill.joke:joke",
+        "lang": "en-US",
+        "samples": ["tell joke", "say joke"],
+    }))
+
+
+def test_opm_exact_match_default_skips_classifier():
+    # default behavior (exact_match unset -> True): classifier must NOT be
+    # consulted when a registered training utterance has an exact hit.
+    bus = FakeBus()
+    pipe = JurebesPipeline(bus=bus, config={"baseline": "logreg", "enable_slots": False})
+    _register_hello_and_joke(pipe, bus)
+
+    with patch.object(opm_mod, "_calc_jurebes", wraps=opm_mod._calc_jurebes) as spy:
+        match = pipe.match_high(["hello"], "en-US", Message("test"))
+        assert match is not None
+        assert match.match_type == "skill.hello:hello"
+        spy.assert_not_called()
+
+
+def test_opm_exact_match_false_always_consults_classifier():
+    # with exact_match=False, the classifier must be consulted even for a
+    # registered training utterance that would otherwise be an exact hit.
+    bus = FakeBus()
+    pipe = JurebesPipeline(bus=bus, config={"baseline": "logreg", "enable_slots": False,
+                                             "exact_match": False})
+    _register_hello_and_joke(pipe, bus)
+    assert pipe.exact_match is False
+
+    with patch.object(opm_mod, "_calc_jurebes", wraps=opm_mod._calc_jurebes) as spy:
+        match = pipe.match_low(["hello"], "en-US", Message("test"))
+        assert match is not None
+        assert match.match_type == "skill.hello:hello"
+        spy.assert_called()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Problem

`JurebesPipeline.calc_intent()` in `jurebes/opm.py` checks the exact-string
dict `self._exact` (populated in `register_intent`) *before* running the
sklearn classifier, unconditionally. On any benchmark whose evaluation
strings overlap the training strings, this exact-match shortcut wins the
match regardless of which `baseline` classifier is configured.

Arena evidence: 5 fighters configured with distinct `baseline` values
produced byte-identical predictions on 1750/1750 benchmark rows — the
classifier was never actually being exercised because every eval utterance
hit the `_exact` shortcut first.

## Fix

Add a config key `exact_match` (default `True`, preserving current
behavior). When set to `False`, `calc_intent()` skips the `_exact` lookup
so the classifier is always consulted, letting benchmarks actually compare
`baseline` configs against each other.

Arena will set `exact_match: false` in its jurebes fighter configs once
this is released.

## Tests

- `test_opm_exact_match_default_skips_classifier`: with `exact_match` unset
  (default True), spies on the module-level `_calc_jurebes` classifier
  call and asserts it is NOT called for a registered training utterance.
- `test_opm_exact_match_false_always_consults_classifier`: with
  `exact_match=False`, asserts `_calc_jurebes` IS called for the same
  utterance. Verified fail-before/pass-after: reverting the guard in
  `calc_intent()` makes this test fail.
- Full suite: `307 passed, 9 skipped` (no regressions).

Not merging — draft only.